### PR TITLE
Feat: 직원 퇴사 시 계정 비활성화, 리스트 조회에서 재직중인 직원만 표시되도록 변경

### DIFF
--- a/grid/src/main/java/org/highfives/grid/user/command/aggregate/Employee.java
+++ b/grid/src/main/java/org/highfives/grid/user/command/aggregate/Employee.java
@@ -120,4 +120,11 @@ public class Employee {
         this.departmentId = departmentId;
     }
 
+    public void setResignTime(String resignTime) {
+        this.resignTime = resignTime;
+    }
+
+    public void setResignYn(YN resignYn) {
+        this.resignYn = resignYn;
+    }
 }

--- a/grid/src/main/java/org/highfives/grid/user/command/controller/UserController.java
+++ b/grid/src/main/java/org/highfives/grid/user/command/controller/UserController.java
@@ -114,11 +114,25 @@ public class UserController {
 
         List<UserDTO> result = userService.modifyMultiUser(modifyList);
         ResUserListVO response =
-                new ResUserListVO(200, "Success to modify all infos", "/users/lists", result);
+                new ResUserListVO(200, "Success to modify all infos", "/users/list", result);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @PutMapping("/{eNum}/status")
+    public ResponseEntity<ResUserVO> resignUser(@PathVariable("eNum") String employeeNumber) {
+
+        if(!userService.deleteUser(employeeNumber))
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    new ResUserVO(400, "No matched user", "/users/list", null)
+            );
+
+        ResUserVO response =
+                new ResUserVO(200, "Success to resign " + employeeNumber + " user",
+                        "/users/list", null);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 
     @GetMapping("/duplication")
     public ResponseEntity<ResUserVO> duplicateInfoCheck(UserDTO givenInfo) {

--- a/grid/src/main/java/org/highfives/grid/user/command/service/UserService.java
+++ b/grid/src/main/java/org/highfives/grid/user/command/service/UserService.java
@@ -18,4 +18,6 @@ public interface UserService {
     List<UserDTO> modifyMultiUser(List<UserDTO> modifyList);
 
     String multiInfoInputCheck(List<UserDTO> modifyList);
+
+    boolean deleteUser(String employeeNumber);
 }

--- a/grid/src/main/java/org/highfives/grid/user/command/service/UserServiceImpl.java
+++ b/grid/src/main/java/org/highfives/grid/user/command/service/UserServiceImpl.java
@@ -1,6 +1,8 @@
 package org.highfives.grid.user.command.service;
 
+import org.highfives.grid.review.command.exception.NotFoundException;
 import org.highfives.grid.user.command.aggregate.Employee;
+import org.highfives.grid.user.command.aggregate.YN;
 import org.highfives.grid.user.command.dto.UserDTO;
 import org.highfives.grid.user.command.repository.UserRepository;
 import org.modelmapper.ModelMapper;
@@ -9,10 +11,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.util.*;
 
 @Service("UserCommandService")
 public class UserServiceImpl implements UserService{
@@ -98,6 +100,25 @@ public class UserServiceImpl implements UserService{
         }
 
         return resultList;
+    }
+
+    @Override
+    @Transactional
+    public boolean deleteUser(String eNum) {
+
+        try {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            String resignTime = simpleDateFormat.format(new Date());
+
+            Employee userInfo = userRepository.findByEmployeeNumber(eNum);
+            userInfo.setResignYn(YN.Y);
+            userInfo.setResignTime(resignTime);
+
+            userRepository.save(userInfo);
+        } catch(NullPointerException e) {
+            return false;
+        }
+        return true;
     }
 
     // 중복 값 입력 예외 처리 메소드

--- a/grid/src/main/resources/org/highfives/grid/user/query/repository/UserMapper.xml
+++ b/grid/src/main/resources/org/highfives/grid/user/query/repository/UserMapper.xml
@@ -91,20 +91,6 @@
         <result property="departmentId" column="department_id"/>
     </resultMap>
 
-    <!--    &lt;!&ndash; 전체 유저 리스트 조회 쿼리 &ndash;&gt;-->
-<!--    <resultMap id="userList" type="org.highfives.grid.user.query.dto.UserDTO">-->
-<!--        <id property="id" column="id"/>-->
-<!--        <result property="profilePath" column="path"/>-->
-<!--        <result property="name" column="employee_name"/>-->
-<!--        <result property="employeeNumber" column="employee_number"/>-->
-<!--        <result property="positionId" column="position_id"/>-->
-<!--        <result property="dutiesId" column="duties_id"/>-->
-<!--        <result property="phoneNumber" column="phone_number"/>-->
-<!--        <result property="absenceYn" column="absence_yn"/>-->
-<!--        <result property="absenceContent" column="absence_content"/>-->
-<!--        <result property="joinTime" column="join_time"/>-->
-<!--    </resultMap>-->
-
     <select id="getUserList" resultMap="userInfo">
         SELECT
         E.id,
@@ -117,6 +103,7 @@
         E.absence_content,
         E.join_time
         FROM Employee E
+        WHERE E.resign_yn = 'N'
     </select>
 
     <!-- 사원 번호로 유저 조회 쿼리    -->

--- a/grid/src/test/java/org/highfives/grid/user/command/service/UserServiceImplTests.java
+++ b/grid/src/test/java/org/highfives/grid/user/command/service/UserServiceImplTests.java
@@ -114,4 +114,14 @@ class UserServiceImplTests {
         );
     }
 
+    @DisplayName("유저 탈퇴")
+    @Test
+    @Transactional
+    void deleteUserTest() {
+
+        Assertions.assertDoesNotThrow(
+                () -> userService.deleteUser("9999999")
+        );
+    }
+
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가<br>
- [ ] 기능 삭제<br>
- [ ] 버그 수정<br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/employee/user-delete -> develop

### 변경 사항
직원 퇴사시 해당 직원의 계정을 비활성화 상태로 만듬 
퇴사한 직원의 계정은 유저 전체 리스트에서 조회 되지 않게 처리.

closed #67 

### 참고 사항 
토큰 기능 구현 후 관리자 권한 가진 유저는 where 조건절 없이 모든 유저 표시 되도록 변경 예정

### 테스트 결과
**비활성화 성공 결과**
![image](https://github.com/beyond-sw-camp/be04-fin-5team-GRID/assets/108782390/157a8c31-7baa-4606-ab72-5e7ecf8216a9)

**유저 목록 조회시 결과 ** - id 1 유저가 비활성화되어 response에 포함되지 않음
![image](https://github.com/beyond-sw-camp/be04-fin-5team-GRID/assets/108782390/d8a809bb-e620-4b09-ab38-93eb20f3bfa4)

